### PR TITLE
chore: update Node.js to v.24

### DIFF
--- a/.github/workflows/automatic-pr-labeler.yaml
+++ b/.github/workflows/automatic-pr-labeler.yaml
@@ -10,9 +10,9 @@ name: Automatic PR Labeler
 
 on:
   pull_request:
-    branches: [develop]
+    branches: [ develop ]
     types:
-      [opened, reopened, synchronize]
+      [ opened, reopened, synchronize ]
 
 permissions:
   pull-requests: write
@@ -24,7 +24,7 @@ jobs:
     if: (github.event.pull_request.merged == false) && (github.event.pull_request.user.login != 'dependabot[bot]') && (github.event.pull_request.user.login != 'github-actions[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: "Execute assign labels"
         id: action-assign-labels

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   delete-dist-tag:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@feature/nodejs24
+    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@main

--- a/.github/workflows/delete-dist-tag.yaml
+++ b/.github/workflows/delete-dist-tag.yaml
@@ -5,4 +5,4 @@ on:
 
 jobs:
   delete-dist-tag:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@main
+    uses: netcracker/qubership-apihub-ci/.github/workflows/delete-dist-tag.yaml@feature/nodejs24

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -1,4 +1,4 @@
-name: frontend-ci 
+name: frontend-ci
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
       - hotfix
       - develop
       - feature/*
-      - bugfix/*      
+      - bugfix/*
     tags:
       - '**'
 

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-frontend-ci-workflow:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@feature/nodejs24
+    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@main

--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -13,4 +13,4 @@ on:
 
 jobs:
   call-frontend-ci-workflow:
-    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@main
+    uses: netcracker/qubership-apihub-ci/.github/workflows/frontend-ci.yaml@feature/nodejs24

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -11,7 +11,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -2,7 +2,7 @@ name: PR Auto-Assignment
 run-name: "Assigning reviewers for PR #${{ github.event.pull_request.number }}"
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize]
+    types: [ opened, reopened, synchronize ]
     branches:
       - main
 
@@ -25,7 +25,7 @@ jobs:
           fi
 
       - name: "Checkout Repository"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/pr-conventional-commits.yaml
+++ b/.github/workflows/pr-conventional-commits.yaml
@@ -16,6 +16,6 @@ jobs:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: webiny/action-conventional-commits@v1.3.0

--- a/.github/workflows/pr-lint-title.yaml
+++ b/.github/workflows/pr-lint-title.yaml
@@ -18,6 +18,6 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -33,14 +33,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Get the common linters configuration"
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: main # fix/superlinter-config
         repository: netcracker/.github
         sparse-checkout: |
           config/linters
     - name: "Upload the common linters configsuration"
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: linter-config
         path: "${{ github.workspace }}/config"
@@ -55,12 +55,12 @@ jobs:
       statuses: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # Full git history is needed to get a proper list of changed files within `super-linter`
         fetch-depth: 0
     - name: "Get the common linters configuration"
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       id: download
       with:
         name: linter-config

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.19",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netcracker/qubership-apihub-api-unifier": "2.7.0",
-        "@netcracker/qubership-apihub-json-crawl": "1.2.0"
+        "@netcracker/qubership-apihub-api-unifier": "feature-nodejs24",
+        "@netcracker/qubership-apihub-json-crawl": "feature-nodejs24"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-npm-gitflow": "3.1.0",
+        "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
         "@types/jest": "29.5.11",
         "@typescript-eslint/eslint-plugin": "6.13.2",
         "@typescript-eslint/parser": "6.13.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@netcracker/qubership-apihub-json-crawl": "1.2.0"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-npm-gitflow": "3.1.0",
+        "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
         "@types/jest": "29.5.11",
         "@typescript-eslint/eslint-plugin": "6.13.2",
         "@typescript-eslint/parser": "6.13.2",
@@ -1703,9 +1703,9 @@
       }
     },
     "node_modules/@netcracker/qubership-apihub-npm-gitflow": {
-      "version": "3.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-npm-gitflow/3.1.0/9d5ec4db1aa7e1fc7ff3d15dcccc1c2741bc06cd",
-      "integrity": "sha512-MoZVHLurOpx1eWb+iSBcpqe6hSTGL60Dv+dcD2Q3Ze0LeE0XPlqLnMFeKyAEQnkq/nynPlnsbNPFGBAgJMYe6w==",
+      "version": "3.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@netcracker/qubership-apihub-npm-gitflow/3.1.1/bb451b4e983f249a7e45e29769e6aa0b9d736fe9",
+      "integrity": "sha512-UV8KqfTRgSKcGswg2SbFmgbfDx0N2HTkaT3yTE8JGo44+P+mBFu3IPGPDsn2yzMLkyJBgOLgyaXdmVeY1G+zuA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.19",
       "license": "Apache-2.0",
       "dependencies": {
-        "@netcracker/qubership-apihub-api-unifier": "feature-nodejs24",
-        "@netcracker/qubership-apihub-json-crawl": "feature-nodejs24"
+        "@netcracker/qubership-apihub-api-unifier": "2.7.0",
+        "@netcracker/qubership-apihub-json-crawl": "1.2.0"
       },
       "devDependencies": {
-        "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
+        "@netcracker/qubership-apihub-npm-gitflow": "3.1.0",
         "@types/jest": "29.5.11",
         "@typescript-eslint/eslint-plugin": "6.13.2",
         "@typescript-eslint/parser": "6.13.2",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-json-crawl": "1.2.0",
-    "@netcracker/qubership-apihub-api-unifier": "2.7.0"
+    "@netcracker/qubership-apihub-json-crawl": "feature-nodejs24",
+    "@netcracker/qubership-apihub-api-unifier": "feature-nodejs24"
   },
   "devDependencies": {
-    "@netcracker/qubership-apihub-npm-gitflow": "3.1.0",
+    "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
     "@types/jest": "29.5.11",
     "@typescript-eslint/eslint-plugin": "6.13.2",
     "@typescript-eslint/parser": "6.13.2",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,11 @@
     "update-lock-file": "update-lock-file @netcracker"
   },
   "dependencies": {
-    "@netcracker/qubership-apihub-json-crawl": "feature-nodejs24",
-    "@netcracker/qubership-apihub-api-unifier": "feature-nodejs24"
+    "@netcracker/qubership-apihub-json-crawl": "dev",
+    "@netcracker/qubership-apihub-api-unifier": "dev"
   },
   "devDependencies": {
-    "@netcracker/qubership-apihub-npm-gitflow": "feature-nodejs24",
+    "@netcracker/qubership-apihub-npm-gitflow": "3.1.1",
     "@types/jest": "29.5.11",
     "@typescript-eslint/eslint-plugin": "6.13.2",
     "@typescript-eslint/parser": "6.13.2",


### PR DESCRIPTION
###   Node.js 24 Migration                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                    
  **Summary**                                 
                                                                                                                                                                                                                                                                                                                    
  - Upgrade Node.js runtime from 20 to 24                                                                                                                                                                                                                                                                           
  - Switch CI workflow (frontend-ci) to feature/nodejs24 branch of qubership-apihub-ci
  - Switch internal dependencies (json-crawl, api-unifier, npm-gitflow) to feature-nodejs24 dist-tag                                                                                                                                                                                                                
                                                               
  **Test plan**

  - CI frontend-ci workflow passes (build + unit tests)
